### PR TITLE
fix(aws-provider): remove matchParent condition

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -300,7 +300,8 @@ func (p *AWSProvider) Zones(ctx context.Context) (map[string]*route53.HostedZone
 				continue
 			}
 
-			if !p.domainFilter.Match(aws.StringValue(zone.Name)) && !p.domainFilter.MatchParent(aws.StringValue(zone.Name)) {
+			// if !p.domainFilter.Match(aws.StringValue(zone.Name)) && !p.domainFilter.MatchParent(aws.StringValue(zone.Name)) {
+			if !p.domainFilter.Match(aws.StringValue(zone.Name)) {
 				continue
 			}
 

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -308,7 +308,7 @@ func TestAWSZones(t *testing.T) {
 		{"tag filter", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{"zone=3"}), defaultDomainFilters, privateZones},
 		{"domain filter zone-1", provider.NewZoneIDFilter([]string{}), provider.NewZoneTypeFilter(""), provider.NewZoneTagFilter([]string{}), endpoint.NewDomainFilter([]string{"zone-1.ext-dns-test-2.teapot.zalan.do"}), map[string]*route53.HostedZone{"/hostedzone/zone-1.ext-dns-test-2.teapot.zalan.do.": allZones["/hostedzone/zone-1.ext-dns-test-2.teapot.zalan.do."]}},
 	} {
-		provider, _ := newAWSProviderWithTagFilter(t, endpoint.NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), ti.zoneIDFilter, ti.zoneTypeFilter, ti.zoneTagFilter, defaultEvaluateTargetHealth, false, nil)
+		provider, _ := newAWSProviderWithTagFilter(t, ti.domainFilters, ti.zoneIDFilter, ti.zoneTypeFilter, ti.zoneTagFilter, defaultEvaluateTargetHealth, false, nil)
 
 		zones, err := provider.Zones(context.Background())
 		require.NoError(t, err)


### PR DESCRIPTION
**Description**

According to official external-dns source repository: PNDS provider is the only one which uses MatchParent functionality. The MatchParent functionality breaks domain and regex domain filters. It also makes PDNS provider behave differently than other providers while having the same configuration. MatchParent can be replaced by using multiple domain filters. After discussion with maintainers we concluded that MatchParent should be removed.

**Checklist**

- [x] Unit tests updated

